### PR TITLE
Reflective

### DIFF
--- a/Project/AOP/StatsdMeasuredMethodAttribute.cs
+++ b/Project/AOP/StatsdMeasuredMethodAttribute.cs
@@ -8,5 +8,6 @@ namespace OpenTable.Services.Statsd.Attributes.AOP
 	[AttributeUsage(AttributeTargets.Method)]
 	public class StatsdMeasuredMethodAttribute : Attribute
 	{
+		public string Name { get; set; }
 	}
 }

--- a/Project/AOP/StatsdMeasuredMethodAttribute.cs
+++ b/Project/AOP/StatsdMeasuredMethodAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenTable.Services.Statsd.Attributes.AOP
+{
+	[AttributeUsage(AttributeTargets.Method)]
+	public class StatsdMeasuredMethodAttribute : Attribute
+	{
+	}
+}

--- a/Project/AOP/StatsdPerformanceMeasureInterceptor.cs
+++ b/Project/AOP/StatsdPerformanceMeasureInterceptor.cs
@@ -122,7 +122,7 @@ namespace OpenTable.Services.Statsd.Attributes.AOP
 					return true;
 				}
 
-				if (invocation.Method.GetCustomAttributes(typeof (StatsdMeasuredMethodAttribute), false).Any())
+				if (invocation.MethodInvocationTarget.GetCustomAttributes(typeof (StatsdMeasuredMethodAttribute), false).Any())
 				{
 					_scanned[invocation.Method.MethodHandle] = true;
 					return true;
@@ -143,9 +143,8 @@ namespace OpenTable.Services.Statsd.Attributes.AOP
 			}
 
 			// if we have any methods which are explicitly marked as statsd measured methods, return false
-			var type = invocation.Method.DeclaringType;
-			if (type != null
-				&& type.GetMethods(BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+			var type = invocation.InvocationTarget.GetType();
+			if (type.GetMethods(BindingFlags.Instance|BindingFlags.Public|BindingFlags.NonPublic|BindingFlags.DeclaredOnly)
 						.Any(m => m.GetCustomAttributes(typeof (StatsdMeasuredMethodAttribute), false).Any()))
 			{
 				return false;

--- a/Project/AOP/StatsdPerformanceMeasureInterceptor.cs
+++ b/Project/AOP/StatsdPerformanceMeasureInterceptor.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Castle.DynamicProxy;
@@ -17,6 +18,9 @@ namespace OpenTable.Services.Statsd.Attributes.AOP
 		// to specify which method to intercept.  In order to do this check once,
 		// results are cached in a dictionary.
 		public List<string> RegexSelector { get; set; }
+
+		// memoized result of InterceptAllMethods, run once on first call to intercept
+		private bool? _interceptAllMethods = null;
 
 		private readonly ConcurrentDictionary<RuntimeMethodHandle, bool> _scanned =
 			new ConcurrentDictionary<RuntimeMethodHandle, bool>();
@@ -95,14 +99,26 @@ namespace OpenTable.Services.Statsd.Attributes.AOP
 
 		private bool CanIntercept(IInvocation invocation)
 		{
-			if (RegexSelector == null || RegexSelector.Count == 0)
+			if (_interceptAllMethods == null)
+			{
+				_interceptAllMethods = InterceptAllMethods(invocation);
+			}
+
+			if (_interceptAllMethods.Value)
 			{
 				return true;
 			}
 
 			if (!_scanned.ContainsKey(invocation.Method.MethodHandle))
 			{
-				if (RegexSelector.Any(regex => Regex.IsMatch(invocation.Method.Name, regex)))
+				if (RegexSelector != null 
+					&& RegexSelector.Any(regex => Regex.IsMatch(invocation.Method.Name, regex)))
+				{
+					_scanned[invocation.Method.MethodHandle] = true;
+					return true;
+				}
+
+				if (invocation.Method.GetCustomAttributes(typeof (StatsdMeasuredMethodAttribute), false).Any())
 				{
 					_scanned[invocation.Method.MethodHandle] = true;
 					return true;
@@ -112,6 +128,27 @@ namespace OpenTable.Services.Statsd.Attributes.AOP
 			}
 
 			return _scanned[invocation.Method.MethodHandle];
+		}
+
+		private bool InterceptAllMethods(IInvocation invocation)
+		{
+			// if we have a non-empty regex selector, return false
+			if (RegexSelector != null && RegexSelector.Any())
+			{
+				return false;
+			}
+
+			// if we have any methods which are explicitly marked as statsd measured methods, return false
+			var type = invocation.Method.DeclaringType;
+			if (type != null
+				&& type.GetMethods(BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+						.Any(m => m.GetCustomAttributes(typeof (StatsdMeasuredMethodAttribute), false).Any()))
+			{
+				return false;
+			}
+
+			// otherwise true
+			return true;
 		}
 	}
 }

--- a/Project/OpenTable.Services.Statsd.Attributes.csproj
+++ b/Project/OpenTable.Services.Statsd.Attributes.csproj
@@ -69,6 +69,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AOP\StatsdMeasuredMethodAttribute.cs" />
     <Compile Include="AOP\StatsdPerformanceMeasureInterceptor.cs" />
     <Compile Include="Common\CommonHelpers.cs" />
     <Compile Include="Filters\StatsdPerformanceMeasureAttribute.cs" />


### PR DESCRIPTION
I've added the option of using method-level attributes to an intercepted class to identify the methods for which metrics will be gathered.  This is intended as an alternative to the use of regular expressions.  I have not deprecated the regular expression mechanism -- it will still work -- so this is not a breaking change.

The marker attribute is named StatsdMeasuredMethodAttribute.  If an intercepted class has neither regular expressions nor methods which are decorated with StatsdMeasuredMethodAttribute, then all methods are measured.

Memoization is done in the same way for reflection as was done for regular expressions.