### PR TITLE
fix the case where logging can throw an exception when response is null…

### DIFF
--- a/Project/Common/CommonHelpers.cs
+++ b/Project/Common/CommonHelpers.cs
@@ -1,121 +1,126 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web.Http.Filters;
 using OpenTable.Services.Statsd.Attributes.Statsd;
 
 namespace OpenTable.Services.Statsd.Attributes.Common
 {
-	public class CommonHelpers
-	{
+    public class CommonHelpers
+    {
 
-		[ThreadStatic] public static HttpRequestHeaders Headers;
-		
-		private const int MaxUserAgentLength = 60;
+        [ThreadStatic]
+        public static HttpRequestHeaders Headers;
 
-		public static void TrySleepRetry(Action action, TimeSpan sleep, Action successCallback, Action failureCallback)
-		{
-			// on a separate thread, 
-			// execute the action
-			// if it doesn't throw an exception, return
-			// otherwise log the exception, sleep, and repeat
-			Task.Factory.StartNew(() =>
-			{
-				while (true)
-				{
-					try
-					{
-						action();
-						successCallback();
-						break;
-					}
-					catch (Exception e)
-					{
-						try
-						{
-							failureCallback();
-						}
-						catch (Exception)
-						{
-							// ignored
-						}
-					}
+        private const int MaxUserAgentLength = 60;
 
-					Thread.Sleep(sleep);
-				}
-			},
-				TaskCreationOptions.LongRunning);
-		}
+        public static Func<Exception, HttpActionExecutedContext, HttpStatusCode> ExceptionToStatusCode { get; set; }
 
-		public static string GetReferringService()
-		{
-			try
-			{
-				return GetReferringService(Headers);
-			}
-			catch
-			{
-				return StatsdConstants.OtSrviceNameValue;
-			}
-		}
+        public static void TrySleepRetry(Action action, TimeSpan sleep, Action successCallback, Action failureCallback)
+        {
+            // on a separate thread, 
+            // execute the action
+            // if it doesn't throw an exception, return
+            // otherwise log the exception, sleep, and repeat
+            Task.Factory.StartNew(() =>
+            {
+                while (true)
+                {
+                    try
+                    {
+                        action();
+                        successCallback();
+                        break;
+                    }
+                    catch (Exception)
+                    {
+                        try
+                        {
+                            failureCallback();
+                        }
+                        catch (Exception)
+                        {
+                            // ignored
+                        }
+                    }
 
-		public static string GetReferringService(HttpRequestHeaders headers)
-		{
-			if (headers == null) return StatsdConstants.Undefined;
+                    Thread.Sleep(sleep);
+                }
+            },
+                TaskCreationOptions.LongRunning);
+        }
 
-			// fetch referring service from request headers 
-			IEnumerable<string> headerValues;
-			if (headers.TryGetValues(StatsdConstants.OtReferringservice, out headerValues))
-			{
-				var otReferringservice = headerValues.FirstOrDefault();
+        public static string GetReferringService()
+        {
+            try
+            {
+                return GetReferringService(Headers);
+            }
+            catch
+            {
+                return StatsdConstants.OtSrviceNameValue;
+            }
+        }
 
-				if (!string.IsNullOrEmpty(otReferringservice))
-					return otReferringservice.Replace('.', '_');
-			}
+        public static string GetReferringService(HttpRequestHeaders headers)
+        {
+            if (headers == null) return StatsdConstants.Undefined;
 
-			// fetch user agent from request headers
-			var match = Regex.Match(
-				headers.UserAgent.ToString(),
-				@"^(\w+)/",
-				RegexOptions.IgnoreCase);
+            // fetch referring service from request headers 
+            IEnumerable<string> headerValues;
+            if (headers.TryGetValues(StatsdConstants.OtReferringservice, out headerValues))
+            {
+                var otReferringservice = headerValues.FirstOrDefault();
 
-			var userAgent = (match.Success) ? match.Groups[1].Value.Replace('.', '_') : null;
+                if (!string.IsNullOrEmpty(otReferringservice))
+                    return otReferringservice.Replace('.', '_');
+            }
 
-			if (!string.IsNullOrEmpty(userAgent))
-				userAgent = new string(userAgent.Take(MaxUserAgentLength).ToArray());
+            // fetch user agent from request headers
+            var match = Regex.Match(
+                headers.UserAgent.ToString(),
+                @"^(\w+)/",
+                RegexOptions.IgnoreCase);
 
-			return userAgent ?? "undefined";
-		}
+            var userAgent = (match.Success) ? match.Groups[1].Value.Replace('.', '_') : null;
 
-		public static string Sanitize(string input)
-		{
-			const string WhitespaceRegex = @"\s+";
-			const string ForwardSlashRegex = @"/";
-			const string UncleanCharacterRegex = @"[^a-zA-Z_\-0-9\.]";
+            if (!string.IsNullOrEmpty(userAgent))
+                userAgent = new string(userAgent.Take(MaxUserAgentLength).ToArray());
 
-			var sanitized = input;
-			sanitized = Regex.Replace(sanitized, WhitespaceRegex, "_");
-			sanitized = Regex.Replace(sanitized, ForwardSlashRegex, "-");
-			sanitized = Regex.Replace(sanitized, UncleanCharacterRegex, "");
-			return sanitized;
-		}
+            return userAgent ?? "undefined";
+        }
 
-		public static string MetricName(bool exceptionThrown, string actionName)
-		{
-			var metricName = string.Format(
-				"{0}.{1}.{2}.{3}.{4}.{5}",
-				StatsdConstants.MethodCall,
-				CommonHelpers.GetReferringService(),
-				actionName,
-				exceptionThrown
-					? "failure"
-					: "success",
-				StatsdConstants.Undefined,
-				StatsdConstants.Undefined).ToLower();
-			return metricName;
-		}
-	}
+        public static string Sanitize(string input)
+        {
+            const string WhitespaceRegex = @"\s+";
+            const string ForwardSlashRegex = @"/";
+            const string UncleanCharacterRegex = @"[^a-zA-Z_\-0-9\.]";
+
+            var sanitized = input;
+            sanitized = Regex.Replace(sanitized, WhitespaceRegex, "_");
+            sanitized = Regex.Replace(sanitized, ForwardSlashRegex, "-");
+            sanitized = Regex.Replace(sanitized, UncleanCharacterRegex, "");
+            return sanitized;
+        }
+
+        public static string MetricName(bool exceptionThrown, string actionName)
+        {
+            var metricName = string.Format(
+                "{0}.{1}.{2}.{3}.{4}.{5}",
+                StatsdConstants.MethodCall,
+                CommonHelpers.GetReferringService(),
+                actionName,
+                exceptionThrown
+                    ? "failure"
+                    : "success",
+                StatsdConstants.Undefined,
+                StatsdConstants.Undefined).ToLower();
+            return metricName;
+        }
+    }
 }

--- a/Project/Filters/StatsdPerformanceMeasureAttribute.cs
+++ b/Project/Filters/StatsdPerformanceMeasureAttribute.cs
@@ -70,6 +70,8 @@ namespace OpenTable.Services.Statsd.Attributes.Filters
                 var otEndpoint = string.Format("{0}-{1}", actionName, apiVersion).ToLower();
                 if (actionExecutedContext.Response != null)
                 {
+                    // controller returns HttpResponseMessage or threw a HttpResponseException
+
                     statusCode = (int)actionExecutedContext.Response.StatusCode;
 
                     // Look for endpoint name in the response headers, if one exists we will use it to 
@@ -87,6 +89,8 @@ namespace OpenTable.Services.Statsd.Attributes.Filters
                 }
                 else if (actionExecutedContext.Exception != null)
                 {
+                    // controllers threw exception that is not typeof(HttpResponseException)
+
                     if (CommonHelpers.ExceptionToStatusCode != null)
                     {
                         var statusCodeEnum = CommonHelpers.ExceptionToStatusCode(actionExecutedContext.Exception,

--- a/Project/Filters/StatsdPerformanceMeasureAttribute.cs
+++ b/Project/Filters/StatsdPerformanceMeasureAttribute.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
@@ -10,127 +13,151 @@ using Stopwatch = System.Diagnostics.Stopwatch;
 
 namespace OpenTable.Services.Statsd.Attributes.Filters
 {
-	[AttributeUsage(AttributeTargets.Method, Inherited = true)]
-	public class StatsdPerformanceMeasureAttribute : ActionFilterAttribute
-	{
-	    private const string StopwatchKey = "StatsdPerformanceMeasureAttribute_stopwatchKey";
+    [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+    public class StatsdPerformanceMeasureAttribute : ActionFilterAttribute
+    {
+        private const string StopwatchKey = "StatsdPerformanceMeasureAttribute_stopwatchKey";
 
-	    private const int MaxUserAgentLength = 60;
+        private const int MaxUserAgentLength = 60;
 
-	    // regular expression to match verion number of Api, e.g.: @"availability/(\w+)/"
-		public string ApiVersionPattern { get; set; }
+        // regular expression to match verion number of Api, e.g.: @"availability/(\w+)/"
+        public string ApiVersionPattern { get; set; }
 
-		public string DefaultApiVersion { get; set; }
+        public string DefaultApiVersion { get; set; }
 
-		public string SuppliedActionName { get; set; }
-		
-		public override void OnActionExecuting(HttpActionContext actionContext)
-		{
-			try
-			{
-				var stopwatch = new Stopwatch();
-			    actionContext.Request.Properties[StopwatchKey] = stopwatch;
-				stopwatch.Start();
-				CommonHelpers.Headers = actionContext.Request.Headers;
-			}
-			finally
-			{
-				base.OnActionExecuting(actionContext);
-			}
-		}
+        public string SuppliedActionName { get; set; }
 
-		public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
-		{
-			try
-			{
-				if (!StatsdClientWrapper.IsEnabled)
-				{
-					return;
-				}
+        public override void OnActionExecuting(HttpActionContext actionContext)
+        {
+            try
+            {
+                var stopwatch = new Stopwatch();
+                actionContext.Request.Properties[StopwatchKey] = stopwatch;
+                stopwatch.Start();
+                CommonHelpers.Headers = actionContext.Request.Headers;
+            }
+            finally
+            {
+                base.OnActionExecuting(actionContext);
+            }
+        }
+
+        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+        {
+            try
+            {
+                if (!StatsdClientWrapper.IsEnabled)
+                {
+                    return;
+                }
 
                 var stopwatch = actionExecutedContext.Request.Properties[StopwatchKey] as Stopwatch;
 
-				if (stopwatch == null) return;
+                if (stopwatch == null) return;
 
-				var elapsedMilliseconds = (int)stopwatch.ElapsedMilliseconds;
-				stopwatch.Reset();
+                var elapsedMilliseconds = (int)stopwatch.ElapsedMilliseconds;
+                stopwatch.Reset();
 
-				var actionName = string.IsNullOrEmpty(SuppliedActionName)
-									? actionExecutedContext.ActionContext.ActionDescriptor.ActionName
-									: SuppliedActionName;
+                var actionName = string.IsNullOrEmpty(SuppliedActionName)
+                                    ? actionExecutedContext.ActionContext.ActionDescriptor.ActionName
+                                    : SuppliedActionName;
 
-				var apiVersion = GetApiVersion(actionExecutedContext);
+                var apiVersion = GetApiVersion(actionExecutedContext);
 
-				var httpVerb = actionExecutedContext.Request.Method.ToString();
+                var httpVerb = actionExecutedContext.Request.Method.ToString();
 
-				var statusCode = (int)actionExecutedContext.Response.StatusCode;
+                int statusCode = 0;
+                var otEndpoint = string.Format("{0}-{1}", actionName, apiVersion).ToLower();
+                if (actionExecutedContext.Response != null)
+                {
+                    statusCode = (int)actionExecutedContext.Response.StatusCode;
 
-				// Look for endpoint name in the response headers, if one exists we will use it to 
-				// publish metircs.  If not will default to action name and will set the header
-				// value as such for upstream services. 
-				IEnumerable<string> headerValues;
-				var otEndpoint = string.Format("{0}-{1}", actionName, apiVersion).ToLower();
-				if (actionExecutedContext.Response.Headers.TryGetValues(StatsdConstants.OtEndpoint, out headerValues))
-				{
-					otEndpoint = string.Format("{0}-{1}", headerValues.FirstOrDefault() ?? actionName, apiVersion).ToLower();
-				}
-				else
-				{
-					actionExecutedContext.Response.Headers.Add(StatsdConstants.OtEndpoint, otEndpoint);
-				}
+                    // Look for endpoint name in the response headers, if one exists we will use it to 
+                    // publish metircs.  If not will default to action name and will set the header
+                    // value as such for upstream services. 
+                    IEnumerable<string> headerValues;
+                    if (actionExecutedContext.Response.Headers.TryGetValues(StatsdConstants.OtEndpoint, out headerValues))
+                    {
+                        otEndpoint = string.Format("{0}-{1}", headerValues.FirstOrDefault() ?? actionName, apiVersion).ToLower();
+                    }
+                    else
+                    {
+                        actionExecutedContext.Response.Headers.Add(StatsdConstants.OtEndpoint, otEndpoint);
+                    }
+                }
+                else if (actionExecutedContext.Exception != null)
+                {
+                    if (CommonHelpers.ExceptionToStatusCode != null)
+                    {
+                        var statusCodeEnum = CommonHelpers.ExceptionToStatusCode(actionExecutedContext.Exception,
+                            actionExecutedContext);
+                        statusCode = (int)statusCodeEnum;
+                        actionExecutedContext.Response = actionExecutedContext.Request.CreateResponse(statusCodeEnum);
+                        actionExecutedContext.Response.Headers.Add(StatsdConstants.OtEndpoint, otEndpoint);
+                    }
+                }
 
-				var metricName = string.Format(
-					"{0}.{1}.{2}.{3}.{4}.{5}",
-					StatsdConstants.HttpRequestIn,
-					GetReferringService(actionExecutedContext),
-					otEndpoint,
-					actionExecutedContext.Response.IsSuccessStatusCode
-						? StatsdConstants.HighlevelStatus.Success
-						: StatsdConstants.HighlevelStatus.Failure,
-					httpVerb,
-					statusCode).Replace('_', '-').ToLower();
 
-				StatsdClientWrapper.Timer(metricName, elapsedMilliseconds);
-				StatsdClientWrapper.Counter(metricName);
+                var status = IsSuccessStatusCode(statusCode) ? StatsdConstants.HighlevelStatus.Success : StatsdConstants.HighlevelStatus.Failure;
+                // not being able to read status code will result in status code being set to undefined
+                var statusCodeString = statusCode == 0
+                    ? StatsdConstants.Undefined
+                    : statusCode.ToString(CultureInfo.InvariantCulture);
+                var metricName = string.Format(
+                    "{0}.{1}.{2}.{3}.{4}.{5}",
+                    StatsdConstants.HttpRequestIn,
+                    GetReferringService(actionExecutedContext),
+                    otEndpoint,
+                    status,
+                    httpVerb,
+                    statusCodeString).Replace('_', '-').ToLower();
 
-				EnrichResponseHeaders(actionExecutedContext);
-			}
-			finally
-			{
-				base.OnActionExecuted(actionExecutedContext);
-			}
-		}
+                StatsdClientWrapper.Timer(metricName, elapsedMilliseconds);
+                StatsdClientWrapper.Counter(metricName);
 
-		private static void EnrichResponseHeaders(HttpActionExecutedContext actionExecutedContext)
-		{
-			if (!actionExecutedContext.Response.Headers.Contains(StatsdConstants.OtSrviceName) &&
-				!string.IsNullOrEmpty(StatsdConstants.OtSrviceNameValue))
-			{
-				actionExecutedContext.Response.Headers.Add(
-					StatsdConstants.OtSrviceName,
-					StatsdConstants.OtSrviceNameValue);
-			}
-		}
+                EnrichResponseHeaders(actionExecutedContext);
+            }
+            finally
+            {
+                base.OnActionExecuted(actionExecutedContext);
+            }
+        }
 
-		private string GetApiVersion(HttpActionExecutedContext httpActionExecutedContext)
-		{
-			if (ApiVersionPattern == null)
-			{
-				return (DefaultApiVersion ?? "v0");
-			}
+        private static bool IsSuccessStatusCode(int statusCode)
+        {
+            return statusCode >= 200 && statusCode <= 399;
+        }
 
-			var path = httpActionExecutedContext.Request.RequestUri.AbsolutePath;
-			var match = Regex.Match(path, ApiVersionPattern, RegexOptions.IgnoreCase);
+        private static void EnrichResponseHeaders(HttpActionExecutedContext actionExecutedContext)
+        {
+            if (!actionExecutedContext.Response.Headers.Contains(StatsdConstants.OtSrviceName) &&
+                !string.IsNullOrEmpty(StatsdConstants.OtSrviceNameValue))
+            {
+                actionExecutedContext.Response.Headers.Add(
+                    StatsdConstants.OtSrviceName,
+                    StatsdConstants.OtSrviceNameValue);
+            }
+        }
 
-			if (match.Success)
-				return match.Groups[1].Value;
+        private string GetApiVersion(HttpActionExecutedContext httpActionExecutedContext)
+        {
+            if (ApiVersionPattern == null)
+            {
+                return (DefaultApiVersion ?? "v0");
+            }
 
-			return (DefaultApiVersion ?? "v0");
-		}
+            var path = httpActionExecutedContext.Request.RequestUri.AbsolutePath;
+            var match = Regex.Match(path, ApiVersionPattern, RegexOptions.IgnoreCase);
 
-		private static string GetReferringService(HttpActionExecutedContext httpActionExecutedContext)
-		{
-			return CommonHelpers.GetReferringService(httpActionExecutedContext.Request.Headers);
-		}
-	}
+            if (match.Success)
+                return match.Groups[1].Value;
+
+            return (DefaultApiVersion ?? "v0");
+        }
+
+        private static string GetReferringService(HttpActionExecutedContext httpActionExecutedContext)
+        {
+            return CommonHelpers.GetReferringService(httpActionExecutedContext.Request.Headers);
+        }
+    }
 }

--- a/Project/Statsd/StatsdClientFactory.cs
+++ b/Project/Statsd/StatsdClientFactory.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Net;
+using System.Web.Http.Filters;
 using OpenTable.Services.Statsd.Attributes.Common;
 using StatsdClient;
 
@@ -13,8 +15,10 @@ namespace OpenTable.Services.Statsd.Attributes.Statsd
             string dataCenterRegion,
             string serviceType,
             int failureBackoffSecs = 60,
-            Action failureCallback = null)
+            Action failureCallback = null,
+            Func<Exception, HttpActionExecutedContext, HttpStatusCode> exceptionToStatusCode = null)
         {
+            CommonHelpers.ExceptionToStatusCode = exceptionToStatusCode;
             CommonHelpers.TrySleepRetry(
 
                 // action
@@ -37,8 +41,10 @@ namespace OpenTable.Services.Statsd.Attributes.Statsd
             string dataCenterRegion,
             string serviceType,
             int failureBackoffSecs = 60,
-            Action failureCallback = null)
+            Action failureCallback = null,
+            Func<Exception, HttpActionExecutedContext, HttpStatusCode> exceptionToStatusCode = null)
         {
+            CommonHelpers.ExceptionToStatusCode = exceptionToStatusCode;
             CommonHelpers.TrySleepRetry(
 
                 // action

--- a/Project/Statsd/StatsdClientWrapper.cs
+++ b/Project/Statsd/StatsdClientWrapper.cs
@@ -25,8 +25,6 @@ namespace OpenTable.Services.Statsd.Attributes.Statsd
             {
                 StatsdClient.Metrics.Counter(statName, value, sampleRate);
             }
-
-
         }
 
         public static void Timer(string statName, int value, double sampleRate = 1)


### PR DESCRIPTION
Fix the case where logging can throw an exception when response is null. Response can be null when an exception is thrown in the request even if its later handled by an exception filter. So there is also a mechanism now to allow the clients to pass an exception => status code mapper function.