### PR TITLE
Sanitize user agent

### DIFF
--- a/OpenTable.Services.Statsd.Attributes.NuSpec
+++ b/OpenTable.Services.Statsd.Attributes.NuSpec
@@ -10,18 +10,17 @@
         <description>Attributes for method timing with metrics pushed to statsd</description>
         <copyright>Copyright OpenTable 2015</copyright>
         <dependencies>
-            <group>
-                <dependency id="Castle.Core" version="3.2" />
-                <dependency id="StatsdClient" version="1.0" />
-            </group>
-
             <group targetFramework="net40">
+                <dependency id="Castle.Core" version="3.2" />
+                <dependency id="StatsdClient" version="1.0.0.19" />
                 <dependency id="Microsoft.AspNet.WebApi.Core" version="4.0" />
                 <dependency id="Microsoft.Net.Http" version="2.0" />
                 <dependency id="Newtonsoft.Json" version="4.5" />
             </group>
 
             <group targetFramework="net45">
+                <dependency id="Castle.Core" version="3.2" />
+                <dependency id="StatsdClient" version="1.0.0.19" />
                 <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2" />
                 <dependency id="Newtonsoft.Json" version="6.0" />
             </group>


### PR DESCRIPTION
Changes include
* Added castle core and statsd to both target frameworks
* Pinned version of statsd client to 1.0.0.19 since 1.0 was pulling in 1.0.0.14 which was two years old and was missing a method
* Added regular expression to pull out some resemblance of a user agent incase of a malformed user agent string or ot-referring service is passed in. 