### PR TITLE
Ensure there is a response before accessing

### DIFF
--- a/Project/Filters/StatsdPerformanceMeasureAttribute.cs
+++ b/Project/Filters/StatsdPerformanceMeasureAttribute.cs
@@ -133,7 +133,9 @@ namespace OpenTable.Services.Statsd.Attributes.Filters
 
         private static void EnrichResponseHeaders(HttpActionExecutedContext actionExecutedContext)
         {
-            if (!actionExecutedContext.Response.Headers.Contains(StatsdConstants.OtSrviceName) &&
+            if (actionExecutedContext.Response != null &&
+                actionExecutedContext.Response.Headers != null &&
+                !actionExecutedContext.Response.Headers.Contains(StatsdConstants.OtSrviceName) &&
                 !string.IsNullOrEmpty(StatsdConstants.OtSrviceNameValue))
             {
                 actionExecutedContext.Response.Headers.Add(


### PR DESCRIPTION
This can be null if the application has failed for any reason and no response has been generated.

Failing to check this could (and in the case of the reviews api) cause the underlying exception (that caused the response to be null) to be lost.